### PR TITLE
fix: allow submit on stack-extend

### DIFF
--- a/src/pages/stacking/stack-extend/components/stack-extend-layout.tsx
+++ b/src/pages/stacking/stack-extend/components/stack-extend-layout.tsx
@@ -134,6 +134,7 @@ export function StackExtendLayout(props: StackExtendLayoutProps) {
                   <Button
                     _loading={{ opacity: 0.5 }}
                     disabled={hasErrors(errors) || isContractCallExtensionPageOpen}
+                    type="submit"
                   >
                     <Flex flexDirection="row" alignItems="center" justifyContent="center">
                       <IconLock />


### PR DESCRIPTION
The <button> on `stack-extend` didn't have `type="submit"`, so you couldn't submit the form.