### PR TITLE
Remove client from contract call options (#237)

### DIFF
--- a/src/pages/stacking/pool-admin/delegate-stack-extend/utils.ts
+++ b/src/pages/stacking/pool-admin/delegate-stack-extend/utils.ts
@@ -59,7 +59,7 @@ export function createHandleSubmit({
       extendCount: values.extendCount,
     });
 
-    console.log(delegateStackExtendOptions);
+    delegateStackExtendOptions.client = undefined;
 
     showContractCall({
       // Type coercion necessary because the `network` property returned by

--- a/src/pages/stacking/pool-admin/delegate-stack-increase/utils.ts
+++ b/src/pages/stacking/pool-admin/delegate-stack-increase/utils.ts
@@ -82,6 +82,7 @@ export function createHandleSubmit({
       increaseBy: increaseBy.toString(),
       poxAddress: values.poxAddress,
     });
+    delegateStackStxOptions.client = undefined;
 
     showContractCall({
       // Type coercion necessary because the `network` property returned by

--- a/src/pages/stacking/pool-admin/delegate-stack-stx/utils.ts
+++ b/src/pages/stacking/pool-admin/delegate-stack-stx/utils.ts
@@ -79,7 +79,7 @@ export function createHandleSubmit({
       poxAddress: values.poxAddress,
       burnBlockHeight: values.startBurnHt,
     });
-
+    delegateStackStxOptions.client = undefined;
     showContractCall({
       // Type coercion necessary because the `network` property returned by
       // `client.getStackingContract()` has a wider type than allowed by `showContractCall`. Despite

--- a/src/pages/stacking/pool-admin/stack-aggregation-commit/utils.ts
+++ b/src/pages/stacking/pool-admin/stack-aggregation-commit/utils.ts
@@ -152,6 +152,7 @@ export function createHandleSubmit({
       maxAmount,
       authId,
     });
+    stackAggregationCommitOptions.client = undefined;
 
     showContractCall({
       // Type coercion necessary because the `network` property returned by

--- a/src/pages/stacking/pool-admin/stack-aggregation-increase/utils.ts
+++ b/src/pages/stacking/pool-admin/stack-aggregation-increase/utils.ts
@@ -153,6 +153,8 @@ export function createHandleSubmit({
       authId,
     });
 
+    stackAggregationIncreaseOptions.client = undefined;
+
     openContractCall({
       // Type coercion necessary because the `network` property returned by
       // `client.getStackingContract()` has a wider type than allowed by `openContractCall`. Despite


### PR DESCRIPTION
This PR
* remove client parameter from contract call options
* fixed #237 