### PR TITLE
Remove client from contract call options

### DIFF
--- a/src/pages/stacking/stack-extend/utils.ts
+++ b/src/pages/stacking/stack-extend/utils.ts
@@ -63,6 +63,7 @@ export function createHandleSubmit({
       maxAmount,
       authId: parseInt(authId),
     });
+    stackExtendOptions.client = undefined;
     setIsContractCallExtensionPageOpen(true);
     showContractCall({
       // Type coercion necessary because the `network` property returned by

--- a/src/pages/stacking/stack-increase/utils.ts
+++ b/src/pages/stacking/stack-increase/utils.ts
@@ -172,6 +172,7 @@ export function createHandleSubmit({
       maxAmount,
       authId: parseInt(authId),
     });
+    stackIncreaseOptions.client = undefined;
     setIsContractCallExtensionPageOpen(true);
     showContractCall({
       // Type coercion necessary because the `network` property returned by


### PR DESCRIPTION
This PR
* fixes more cases of client property in contract call options like #242 